### PR TITLE
feat: conditionally show lottery diff tags

### DIFF
--- a/src/pages/LotteryPage/LotteryContentWithDirHandle.tsx
+++ b/src/pages/LotteryPage/LotteryContentWithDirHandle.tsx
@@ -375,8 +375,14 @@ const LotteryContentWithDirHandle: React.FC = () => {
                     onClick={handleLoadRemoteJson}
                     disabled={remoteJsonLoading}
                   />
-                  <Tag color="green">新增</Tag>
-                  <Tag color="red">移除</Tag>
+                  {currentType &&
+                    differentParts[currentType]?.addedItems.length > 0 && (
+                      <Tag color="green">新增</Tag>
+                    )}
+                  {currentType &&
+                    differentParts[currentType]?.deletedItems.length > 0 && (
+                      <Tag color="red">移除</Tag>
+                    )}
                 </Space>
               }
               loading={remoteJsonLoading}


### PR DESCRIPTION
## Summary
- only render add/remove tags for Notion card when differences exist

## Testing
- `yarn test` *(fails: Command "test" not found)*
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68abe59f6668832ebedf3053b588a9a7