### PR TITLE
Refactor lottery exchange ID translation

### DIFF
--- a/src/pages/LotteryPage/UseLotteryData.tsx
+++ b/src/pages/LotteryPage/UseLotteryData.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { getNotionToken, fetchNotionAllPages } from "../../notion/notionClient";
-import { formatLottery } from "../../services/lottery/lotteryService";
+import { formatLottery, translateExchangeId } from "../../services/lottery/lotteryService";
 import { parseCheckbox, parseRollup, parseRelation } from "../../services/commonFormat";
 import { message } from "antd"; // Ant Design 的消息组件
 
@@ -56,9 +56,10 @@ export const useLotteryData = (databaseId: string) => {
       for (const key in result) {
         if (result.hasOwnProperty(key)) {
           const formattedData = formatLottery(result[key]);
-          if (formattedData.name && formattedData.name !== "") {
+          if (formattedData.exchangeId && formattedData.exchangeId !== "") {
+            const formattedName = translateExchangeId(formattedData.exchangeId);
             newFileArray[exchangeIdBoxId[key]] = {
-              [formattedData.name]: formattedData.result,
+              [formattedName]: formattedData.result,
             };
           }
         }


### PR DESCRIPTION
## Summary
- centralize exchange ID formatting via `translateExchangeId`
- keep raw `exchangeId` during lottery computation and translate only during export
- reuse translation helper for nested exchange IDs

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae845de4988322b9622597bbaf63af