### PR TITLE
refactor: delay translation to formatting step

### DIFF
--- a/LotteryWikiTab_工作原理.md
+++ b/LotteryWikiTab_工作原理.md
@@ -107,17 +107,14 @@ const nameMap: Record<string, string> = {
 };
 
 // 应用翻译
-wiki.gain.forEach((item) => {
-  if (item.name && nameMap[item.name]) {
-    item.name = nameMap[item.name]; // 英文 → 中文
-  }
-});
-```
+// 获取商品名称和抽奖箱名称映射
+const [nameMap, boxNameMap] = await Promise.all([
+  fetchCommodityNameMap(),
+  fetchLotteryBoxNameMap()
+]);
 
-**抽奖箱名称翻译：**
-```typescript
-// 从 lotteryNameService 获取抽奖箱名称映射
-await translateLotteryBoxNames(wikiMap);
+// 在格式化阶段统一翻译
+const map = buildWikiTables(wikiMap, nameMap, boxNameMap);
 ```
 
 ### 5. Wiki表格格式化阶段

--- a/src/pages/LotteryPage/LotteryWikiTab.tsx
+++ b/src/pages/LotteryPage/LotteryWikiTab.tsx
@@ -8,7 +8,6 @@ import { buildWikiTables } from '../../services/lottery/wikiFormatter';
 import { NOTION_DATABASE_LOTTERY } from '../../services/lottery/lotteryNotionQueries';
 import { fetchCommodityNameMap } from '../../services/commodity/commodityNameService';
 import { fetchLotteryBoxNameMap } from '../../services/lottery/lotteryNameService';
-import { translateLotteryBoxNames } from '../../services/lottery/lotteryNameService';
 
 const { Paragraph } = Typography;
 
@@ -50,23 +49,12 @@ const LotteryWikiTab: React.FC = () => {
         }
 
         // 获取商品名称映射和抽奖箱名称映射
-        const [nameMap] = await Promise.all([
-          fetchCommodityNameMap()
+        const [nameMap, boxNameMap] = await Promise.all([
+          fetchCommodityNameMap(),
+          fetchLotteryBoxNameMap()
         ]);
 
-        // 应用抽奖箱名称翻译
-        await translateLotteryBoxNames(wikiMap);
-        
-        // 翻译商品名称
-        for (const wiki of Object.values(wikiMap)) {
-          wiki.gain.forEach((item) => {
-            if (item.name && nameMap[item.name]) {
-              item.name = nameMap[item.name];
-            }
-          });
-        }
-
-        const map = buildWikiTables(wikiMap);
+        const map = buildWikiTables(wikiMap, nameMap, boxNameMap);
         setTables(map);
       } catch (err) {
         console.error(err);


### PR DESCRIPTION
## Summary
- fetch translation maps once and pass to `buildWikiTables`
- translate lottery box and item names during final wiki table formatting
- update documentation for new translation flow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae9261bb0483229961305ffbcd1b1c