### PR TITLE
feat: export lottery chances to csv

### DIFF
--- a/src/services/lottery/wikiFormatter.ts
+++ b/src/services/lottery/wikiFormatter.ts
@@ -149,3 +149,39 @@ export function buildWikiTables(
   return result;
 }
 
+
+export function buildWikiCSVs(
+  map: Record<string, WikiResult>,
+  nameMap: Record<string, string> = {},
+  boxNameMap: Record<string, string> = {}
+): Record<string, string> {
+  const display: Record<string, DisplayItem> = {};
+  for (const [key, item] of Object.entries(map)) {
+    if (item.display) {
+      display[key] = {
+        fallbackTimes: item.fallbackTimes,
+        items: formatWikiSingleGain(map, key)
+      };
+    }
+  }
+  const withChance = formatWikiChance(display);
+  const result: Record<string, string> = {};
+  for (const [exc, data] of Object.entries(withChance)) {
+    const wiki = map[exc];
+    const displayName = translateBoxName(wiki, boxNameMap);
+    const translatedItems = data.items.map((i) => ({
+      ...i,
+      name: nameMap[i.name] || i.name
+    }));
+    let csv = '';
+    if (data.fallbackTimes > 0) {
+      csv += `保底次数,${data.fallbackTimes}\n`;
+    }
+    csv += '奖励内容,奖励数量,概率\n';
+    for (const item of translatedItems) {
+      csv += `${item.name},${item.data},${item.chance}\n`;
+    }
+    result[displayName] = csv;
+  }
+  return result;
+}

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -27,6 +27,18 @@ export function downloadJson(jsonData: any, fileName: string) {
   URL.revokeObjectURL(url);
 }
 
+export function downloadCSV(csvData: string, fileName: string) {
+  const blob = new Blob([csvData], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = fileName.endsWith('.csv') ? fileName : `${fileName}.csv`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
 export function downloadJsonAsZip(fileArray: { [key: string]: any }, zipFileName: string) {
   // 创建一个 JSZip 实例
   const zip = new JSZip();


### PR DESCRIPTION
## Summary
- add `buildWikiCSVs` to generate probability CSVs per lottery box
- provide a CSV download helper
- allow Lottery wiki tab to download per-box CSV files

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aea8a3db00832283d84e665854b847