### PR TITLE
feat: add lottery export enhancements

### DIFF
--- a/src/pages/LotteryPage/LotteryWikiTab.tsx
+++ b/src/pages/LotteryPage/LotteryWikiTab.tsx
@@ -215,6 +215,23 @@ const LotteryWikiTab: React.FC = () => {
         >
           下载全部 CSV
         </Button>
+        <Button
+          icon={<FileMarkdownOutlined />}
+          onClick={() => {
+            const combined = Object.keys(tables)
+              .map((name) => markdowns[name])
+              .filter(Boolean)
+              .join('\n\n');
+            if (combined) {
+              navigator.clipboard.writeText(combined);
+              messageApi.success('已复制全部 Markdown');
+            } else {
+              messageApi.error('Markdown 数据缺失');
+            }
+          }}
+        >
+          复制全部 Markdown
+        </Button>
       </Space>
       <Collapse accordion items={items} />
     </>

--- a/src/pages/LotteryPage/LotteryWikiTab.tsx
+++ b/src/pages/LotteryPage/LotteryWikiTab.tsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useState } from 'react';
-import { Collapse, Button, Typography, message, Space, Progress } from 'antd';
-import { CopyOutlined, DownloadOutlined } from '@ant-design/icons';
+import { Collapse, Button, Typography, message, Space, Progress, Tag } from 'antd';
+import { CopyOutlined, DownloadOutlined, FileMarkdownOutlined } from '@ant-design/icons';
 import { fetchNotionAllPages, getNotionToken } from '../../notion/notionClient';
 import { flatProperty, parseCheckbox, parseRelation } from '../../services/commonFormat';
 import { formatLottery, WikiResult } from '../../services/lottery/lotteryService';
-import { buildWikiTables, buildWikiCSVs } from '../../services/lottery/wikiFormatter';
+import { buildWikiTables, buildWikiCSVs, buildMarkdownTables } from '../../services/lottery/wikiFormatter';
 import { NOTION_DATABASE_LOTTERY } from '../../services/lottery/lotteryNotionQueries';
 import { fetchCommodityNameMap } from '../../services/commodity/commodityNameService';
 import { fetchLotteryBoxNameMap } from '../../services/lottery/lotteryNameService';
-import { downloadCSV } from '../../utils/download';
+import { downloadCSV, downloadCSVAsZip } from '../../utils/download';
 
 const { Paragraph } = Typography;
 
@@ -18,6 +18,8 @@ const LotteryWikiTab: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [tables, setTables] = useState<Record<string, string>>({});
   const [csvs, setCsvs] = useState<Record<string, string>>({});
+  const [markdowns, setMarkdowns] = useState<Record<string, string>>({});
+  const [probabilitySums, setProbabilitySums] = useState<Record<string, number>>({});
   const [messageApi, contextHolder] = message.useMessage();
   const [percent, setPercent] = useState(0);
   const [stage, setStage] = useState('初始化');
@@ -77,10 +79,12 @@ const LotteryWikiTab: React.FC = () => {
         setPercent(90);
         const map = buildWikiTables(wikiMap, nameMap, boxNameMap);
         const csvMap = buildWikiCSVs(wikiMap, nameMap, boxNameMap);
+        const mdMap = buildMarkdownTables(wikiMap, nameMap, boxNameMap);
 
         // 根据hiddenLotteries过滤显示结果
         const filteredMap: Record<string, string> = {};
         const filteredCsvMap: Record<string, string> = {};
+        const filteredMdMap: Record<string, string> = {};
 
         for (const [key, value] of Object.entries(map)) {
           if (!hiddenLotteries.includes(key)) {
@@ -88,10 +92,34 @@ const LotteryWikiTab: React.FC = () => {
             if (csvMap[key]) {
               filteredCsvMap[key] = csvMap[key];
             }
+            if (mdMap[key]) {
+              filteredMdMap[key] = mdMap[key];
+            }
           }
         }
         setTables(filteredMap);
         setCsvs(filteredCsvMap);
+        setMarkdowns(filteredMdMap);
+
+        const sums: Record<string, number> = {};
+        for (const [key, csv] of Object.entries(filteredCsvMap)) {
+          const lines = csv.split(/\r?\n/);
+          let startIndex = 1;
+          if (lines[0] && lines[0].startsWith('保底次数')) {
+            startIndex = 2;
+          }
+          let total = 0;
+          for (let i = startIndex; i < lines.length; i++) {
+            const parts = lines[i].split(',');
+            const chance = parts[2];
+            if (chance && chance !== '保底') {
+              const num = parseFloat(chance.replace(/"|%/g, ''));
+              if (!isNaN(num)) total += num;
+            }
+          }
+          sums[key] = total;
+        }
+        setProbabilitySums(sums);
         setPercent(100);
       } catch (err) {
         console.error(err);
@@ -115,11 +143,16 @@ const LotteryWikiTab: React.FC = () => {
 
   const items = Object.entries(tables).map(([name, table]) => {
     const csv = csvs[name];
+    const md = markdowns[name];
+    const sum = probabilitySums[name];
     return {
       key: name,
       label: name,
       extra: (
         <Space>
+          {sum !== undefined && (
+            <Tag color={Math.abs(sum - 100) < 0.01 ? 'green' : 'red'}>{sum.toFixed(3)}%</Tag>
+          )}
           <Button
             size="small"
             icon={<DownloadOutlined />}
@@ -142,6 +175,19 @@ const LotteryWikiTab: React.FC = () => {
               messageApi.success('已复制');
             }}
           />
+          <Button
+            size="small"
+            icon={<FileMarkdownOutlined />}
+            onClick={(e) => {
+              e.stopPropagation();
+              if (md) {
+                navigator.clipboard.writeText(md);
+                messageApi.success('Markdown 已复制');
+              } else {
+                messageApi.error('Markdown 数据缺失');
+              }
+            }}
+          />
         </Space>
       ),
       children: (
@@ -155,6 +201,21 @@ const LotteryWikiTab: React.FC = () => {
   return (
     <>
       {contextHolder}
+      <Space style={{ marginBottom: 16 }}>
+        <Button
+          icon={<DownloadOutlined />}
+          onClick={() => {
+            if (Object.keys(csvs).length) {
+              downloadCSVAsZip(csvs, 'lottery_csv');
+              messageApi.success('已下载全部 CSV');
+            } else {
+              messageApi.error('CSV 数据缺失');
+            }
+          }}
+        >
+          下载全部 CSV
+        </Button>
+      </Space>
       <Collapse accordion items={items} />
     </>
   );

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -42,6 +42,25 @@ export function downloadCSV(csvData: string, fileName: string) {
   URL.revokeObjectURL(url);
 }
 
+export function downloadCSVAsZip(fileArray: Record<string, string>, zipFileName: string) {
+  const zip = new JSZip();
+
+  Object.entries(fileArray).forEach(([fileName, csvData]) => {
+    const BOM = '\uFEFF';
+    const normalized = csvData.replace(/\r?\n/g, '\r\n');
+    zip.file(`${fileName}.csv`, BOM + normalized);
+  });
+
+  zip
+    .generateAsync({ type: 'blob' })
+    .then((blob) => {
+      saveAs(blob, zipFileName.endsWith('.zip') ? zipFileName : `${zipFileName}.zip`);
+    })
+    .catch((error) => {
+      console.error('Error generating ZIP file:', error);
+    });
+}
+
 export function downloadJsonAsZip(fileArray: { [key: string]: any }, zipFileName: string) {
   // 创建一个 JSZip 实例
   const zip = new JSZip();


### PR DESCRIPTION
## Summary
- show probability sum for each lottery box
- export CSVs in a single ZIP
- support Markdown table export and copy

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aec87271688322b60bb42a2deefe85