### PR TITLE
feat: add language fallback for lottery box names

### DIFF
--- a/src/services/commodity/commodityNameService.ts
+++ b/src/services/commodity/commodityNameService.ts
@@ -33,5 +33,11 @@ export async function fetchCommodityNameMap(): Promise<Record<string, string>> {
     const sampleName = map[sampleId];
   }
   
+  // 特殊处理：coin 和 exp 的翻译
+  map['coin'] = 'EC币';
+  map['exp'] = '大厅经验';
+  
   return map;
 }
+
+

--- a/src/services/lottery/lotteryNameService.ts
+++ b/src/services/lottery/lotteryNameService.ts
@@ -147,9 +147,18 @@ export async function translateLotteryBoxNames(
     }
     
     if (!translatedName) {
-      const langKey = `lobby.lottery.${noPrefix.replace(/_/g, '-')}`;
-      if (langMap[langKey]) {
-        translatedName = langMap[langKey];
+      const base = noPrefix.replace(/_/g, '-');
+      const withHyphenDigits = base.replace(/([a-zA-Z])(\d)/g, '$1-$2');
+      const langKeys = [
+        `lobby.lottery.${withHyphenDigits}`,
+        `lobby.lottery.${base}`,
+        `lobby.lottery.${noPrefix}`
+      ];
+      for (const key of langKeys) {
+        if (langMap[key]) {
+          translatedName = langMap[key];
+          break;
+        }
       }
     }
 

--- a/src/services/lottery/lotteryNameService.ts
+++ b/src/services/lottery/lotteryNameService.ts
@@ -125,7 +125,10 @@ export async function getLotteryBoxConfig(boxId: string): Promise<LotteryBoxConf
  * @param wikiMap 抽奖箱wiki结果映射
  * @returns 翻译后的wikiMap
  */
-export async function translateLotteryBoxNames(wikiMap: Record<string, any>): Promise<void> {
+export async function translateLotteryBoxNames(
+  wikiMap: Record<string, any>,
+  langMap: Record<string, string> = {},
+): Promise<void> {
   const boxNameMap = await fetchLotteryBoxNameMap();
   
   for (const wiki of Object.values(wikiMap)) {
@@ -143,6 +146,13 @@ export async function translateLotteryBoxNames(wikiMap: Record<string, any>): Pr
       }
     }
     
+    if (!translatedName) {
+      const langKey = `lobby.lottery.${noPrefix.replace(/_/g, '-')}`;
+      if (langMap[langKey]) {
+        translatedName = langMap[langKey];
+      }
+    }
+
     if (translatedName) {
       wiki.name = translatedName;
     }

--- a/src/services/lottery/wikiFormatter.ts
+++ b/src/services/lottery/wikiFormatter.ts
@@ -108,7 +108,11 @@ function formatWikiToString(name: string, data: {fallbackTimes: number; items: C
   return result;
 }
 
-function translateBoxName(wiki: WikiResult, boxNameMap: Record<string, string>): string {
+function translateBoxName(
+  wiki: WikiResult,
+  boxNameMap: Record<string, string>,
+  langMap: Record<string, string> = {},
+): string {
   const rawExc = typeof wiki.exc === 'string' ? wiki.exc : '';
   const noPrefix = rawExc.replace(/^exc_lottery_/, '');
   const firstDot = noPrefix.replace('_', '.');
@@ -118,6 +122,10 @@ function translateBoxName(wiki: WikiResult, boxNameMap: Record<string, string>):
     if (boxNameMap[key]) {
       return boxNameMap[key];
     }
+  }
+  const langKey = `lobby.lottery.${noPrefix.replace(/_/g, '-')}`;
+  if (langMap[langKey]) {
+    return langMap[langKey];
   }
   return wiki.name;
 }
@@ -140,7 +148,7 @@ export function buildWikiTables(
   const result: Record<string, string> = {};
   for (const [exc, data] of Object.entries(withChance)) {
     const wiki = map[exc];
-    const displayName = translateBoxName(wiki, boxNameMap);
+    const displayName = translateBoxName(wiki, boxNameMap, nameMap);
     const translatedItems = data.items.map((i) => ({
       ...i,
       name: nameMap[i.name] || i.name
@@ -171,7 +179,7 @@ export function buildMarkdownTables(
   const result: Record<string, string> = {};
   for (const [exc, data] of Object.entries(withChance)) {
     const wiki = map[exc];
-    const displayName = translateBoxName(wiki, boxNameMap);
+    const displayName = translateBoxName(wiki, boxNameMap, nameMap);
     const translatedItems = data.items.map((i) => ({
       ...i,
       name: nameMap[i.name] || i.name,
@@ -221,7 +229,7 @@ export function buildWikiCSVs(
   const result: Record<string, string> = {};
   for (const [exc, data] of Object.entries(withChance)) {
     const wiki = map[exc];
-    const displayName = translateBoxName(wiki, boxNameMap);
+    const displayName = translateBoxName(wiki, boxNameMap, nameMap);
     const translatedItems = data.items.map((i) => ({
       ...i,
       name: nameMap[i.name] || i.name

--- a/src/services/lottery/wikiFormatter.ts
+++ b/src/services/lottery/wikiFormatter.ts
@@ -123,9 +123,17 @@ function translateBoxName(
       return boxNameMap[key];
     }
   }
-  const langKey = `lobby.lottery.${noPrefix.replace(/_/g, '-')}`;
-  if (langMap[langKey]) {
-    return langMap[langKey];
+  const base = noPrefix.replace(/_/g, '-');
+  const withHyphenDigits = base.replace(/([a-zA-Z])(\d)/g, '$1-$2');
+  const langKeys = [
+    `lobby.lottery.${withHyphenDigits}`,
+    `lobby.lottery.${base}`,
+    `lobby.lottery.${noPrefix}`
+  ];
+  for (const key of langKeys) {
+    if (langMap[key]) {
+      return langMap[key];
+    }
   }
   return wiki.name;
 }


### PR DESCRIPTION
## Summary
- fall back to language table when lottery box name is missing
- allow translation helper to accept language map lookup

## Testing
- `npm test` *(fails: Missing script: "test")*
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68aef933b5088322a3aeae80b4779400