### PR TITLE
feat: enhance lottery wiki page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Routes, Route, Navigate, HashRouter } from 'react-router
 import LayoutContainer from './components/LayoutContainer';
 import WelcomePage from './pages/WelcomePage';
 import LotteryPage from './pages/LotteryPage';
+import LotteryWikiPage from './pages/LotteryWikiPage';
 import LegacyWorkshopPage from './pages/LegacyWorkshopPage';
 import WorkshopPage from './pages/WorkshopPage';
 import CommodityPage from './pages/CommodityPage';
@@ -37,6 +38,7 @@ const App: React.FC = () => {
           {/* 默认首页重定向到 /workshop */}
           <Route path="/" element={<Navigate to="/workshop" replace />} />
           <Route path="/lottery" element={<LotteryPage />} />
+          <Route path="/lottery-wiki" element={<LotteryWikiPage />} />
           <Route path="/lworkshop" element={<LegacyWorkshopPage />} />
           <Route path="/workshop" element={<WorkshopPage />} />
           <Route path="/commodity" element={<CommodityPage />} />

--- a/src/components/LayoutContainer.tsx
+++ b/src/components/LayoutContainer.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Layout, Menu, theme } from 'antd';
 import { Link, useLocation } from 'react-router-dom';
-import { ShoppingOutlined, SettingOutlined, AppstoreAddOutlined, BuildOutlined, GiftOutlined} from '@ant-design/icons';
+import { ShoppingOutlined, SettingOutlined, AppstoreAddOutlined, BuildOutlined, GiftOutlined, TableOutlined } from '@ant-design/icons';
 import Sider from "antd/es/layout/Sider";
 
 const { Header, Content, Footer } = Layout;
@@ -16,6 +16,7 @@ const LayoutContainer: React.FC<{ children: React.ReactNode }> = ({ children }) 
     { label: <Link to="/lworkshop">商品表（旧版）</Link>, key: '/lworkshop', icon: <BuildOutlined/> },
     { label: <Link to="/commodity">总分类生成</Link>, key: '/commodity', icon: <AppstoreAddOutlined /> },
     { label: <Link to="/lottery">抽奖箱生成</Link>, key: '/lottery', icon: <GiftOutlined />},
+    { label: <Link to="/lottery-wiki">概率表导出</Link>, key: '/lottery-wiki', icon: <TableOutlined />},
     { label: <Link to="/settings">设置</Link>, key: '/settings', icon: <SettingOutlined />}
   ];
 

--- a/src/pages/LotteryPage/index.tsx
+++ b/src/pages/LotteryPage/index.tsx
@@ -1,11 +1,10 @@
 import React from "react";
 import useMessage from "antd/es/message/useMessage";
-import { Layout, Tabs } from 'antd';
+import { Layout } from 'antd';
 import { Content } from "antd/es/layout/layout";
 import { WorkshopPageContextProvider } from "../WorkshopPage/WorkshopPageContext";
 import LotteryTitleBar from "./LotteryTitleBar";
 import LotteryContent from "./LotteryContent";
-import LotteryWikiTab from "./LotteryWikiTab";
 
 const LotteryPage2: React.FC = () => {
 
@@ -17,13 +16,7 @@ const LotteryPage2: React.FC = () => {
         {messageContext}
         <LotteryTitleBar />
         <Content className={"responsive-padding"} style={{ paddingTop: 8 }}>
-          <Tabs
-            defaultActiveKey="json"
-            items={[
-              { key: 'json', label: 'JSON 同步', children: <LotteryContent /> },
-              { key: 'wiki', label: '概率表导出', children: <LotteryWikiTab /> },
-            ]}
-          />
+          <LotteryContent />
         </Content>
       </Layout>
     </WorkshopPageContextProvider>

--- a/src/pages/LotteryWikiPage.tsx
+++ b/src/pages/LotteryWikiPage.tsx
@@ -320,7 +320,11 @@ const LotteryWikiPage: React.FC = () => {
 
   if (loading) {
     return (
-      <div style={{ textAlign: 'center', padding: '2rem' }}>
+      <div
+        className="responsive-padding"
+        style={{ textAlign: 'center', paddingTop: '2rem' }}
+      >
+        {contextHolder}
         <Progress
           percent={percent}
           status={stageIndex === stages.length - 1 ? 'success' : 'active'}
@@ -397,9 +401,9 @@ const LotteryWikiPage: React.FC = () => {
   });
 
   return (
-    <>
+    <div className="responsive-padding">
       {contextHolder}
-      <Title level={2} style={{ marginTop: 0 }}>概率表导出</Title>
+      <Title style={{ margin: '8px 0 24px' }}>概率表导出</Title>
       <Space direction="vertical" size="middle" style={{ marginBottom: 16, width: '100%' }}>
         <Space wrap size="middle">
           <Upload beforeUpload={handleUpload} showUploadList={false} accept=".json" multiple>
@@ -449,7 +453,7 @@ const LotteryWikiPage: React.FC = () => {
         )}
       </Space>
       {items.length > 0 && <Collapse accordion items={items} />}
-    </>
+    </div>
   );
 };
 

--- a/src/pages/LotteryWikiPage.tsx
+++ b/src/pages/LotteryWikiPage.tsx
@@ -318,23 +318,6 @@ const LotteryWikiPage: React.FC = () => {
     { key: 'markdown-download', label: '下载全部 Markdown' }
   ];
 
-  if (loading) {
-    return (
-      <div
-        className="responsive-padding"
-        style={{ textAlign: 'center', paddingTop: '2rem' }}
-      >
-        {contextHolder}
-        <Progress
-          percent={percent}
-          status={stageIndex === stages.length - 1 ? 'success' : 'active'}
-          strokeColor={{ from: '#108ee9', to: '#87d068' }}
-        />
-        <div style={{ marginTop: 16 }}>{currentStage}</div>
-      </div>
-    );
-  }
-
   const items = Object.entries(tables).map(([name, table]) => {
     const csv = csvs[name];
     const md = markdowns[name];
@@ -345,7 +328,7 @@ const LotteryWikiPage: React.FC = () => {
       extra: (
         <Space>
           {sum !== undefined && (
-            <Tag color={Math.abs(sum - 100) < 0.01 ? 'green' : 'red'}>{sum.toFixed(3)}%</Tag>
+            <Tag color={sum >= 99 && sum <= 101 ? 'green' : 'red'}>{sum.toFixed(3)}%</Tag>
           )}
           <Dropdown
             menu={{
@@ -404,55 +387,69 @@ const LotteryWikiPage: React.FC = () => {
     <div className="responsive-padding">
       {contextHolder}
       <Title style={{ margin: '8px 0 24px' }}>概率表导出</Title>
-      <Space direction="vertical" size="middle" style={{ marginBottom: 16, width: '100%' }}>
-        <Space wrap size="middle">
-          <Upload beforeUpload={handleUpload} showUploadList={false} accept=".json" multiple>
-            <Button
-              icon={uploadedFiles.length > 0 ? <CheckCircleOutlined /> : <UploadOutlined />}
-              type={uploadedFiles.length > 0 ? 'primary' : 'default'}
-            >
-              {uploadedFiles.length > 0 ? `商品配置 (${uploadedFiles.length})` : '上传JSON抽奖箱配置'}
-            </Button>
-          </Upload>
+      
+      {loading ? (
+        <div style={{ textAlign: 'center', paddingTop: '2rem' }}>
+          <Progress
+            percent={percent}
+            status={stageIndex === stages.length - 1 ? 'success' : 'active'}
+            strokeColor={{ from: '#108ee9', to: '#87d068' }}
+          />
+          <div style={{ marginTop: 16 }}>{currentStage}</div>
+        </div>
+      ) : (
+        <>
+          <Space direction="vertical" size="middle" style={{ marginBottom: 16, width: '100%' }}>
+            <Space wrap size="small">
+              <Upload beforeUpload={handleUpload} showUploadList={false} accept=".json" multiple>
+                <Button
+                  icon={uploadedFiles.length > 0 ? <CheckCircleOutlined /> : <UploadOutlined />}
+                  type={uploadedFiles.length > 0 ? 'primary' : 'default'}
+                >
+                  {uploadedFiles.length > 0 ? `商品配置 (${uploadedFiles.length})` : '上传JSON抽奖箱配置'}
+                </Button>
+              </Upload>
 
-          <Upload beforeUpload={handleLangUpload} showUploadList={false} accept=".json">
-            <Button
-              icon={langFile ? <CheckCircleOutlined /> : <UploadOutlined />}
-              type={langFile ? 'primary' : 'default'}
-            >
-              {langFile ? langFile.name : '上传语言配置'}
-            </Button>
-          </Upload>
+              <Upload beforeUpload={handleLangUpload} showUploadList={false} accept=".json">
+                <Button
+                  icon={langFile ? <CheckCircleOutlined /> : <UploadOutlined />}
+                  type={langFile ? 'primary' : 'default'}
+                >
+                  {langFile ? langFile.name : '上传语言配置'}
+                </Button>
+              </Upload>
 
-          <Upload beforeUpload={handleKillerUpload} showUploadList={false} accept=".json">
-            <Button
-              icon={killerFile ? <CheckCircleOutlined /> : <UploadOutlined />}
-              type={killerFile ? 'primary' : 'default'}
-            >
-              {killerFile ? killerFile.name : '上传密室杀手商品配置'}
-            </Button>
-          </Upload>
+              <Upload beforeUpload={handleKillerUpload} showUploadList={false} accept=".json">
+                <Button
+                  icon={killerFile ? <CheckCircleOutlined /> : <UploadOutlined />}
+                  type={killerFile ? 'primary' : 'default'}
+                >
+                  {killerFile ? killerFile.name : '上传密室杀手商品配置'}
+                </Button>
+              </Upload>
 
-          <Button type="primary" icon={<PlayCircleOutlined />} onClick={load}>
-            开始
-          </Button>
-          <Dropdown menu={{ items: exportAllItems, onClick: handleExportAll }}>
-            <Button icon={<ExportOutlined />}>导出</Button>
-          </Dropdown>
-        </Space>
+              <Button type="primary" icon={<PlayCircleOutlined />} onClick={load}>
+                开始
+              </Button>
+              <Dropdown menu={{ items: exportAllItems, onClick: handleExportAll }}>
+                <Button icon={<ExportOutlined />}>导出</Button>
+              </Dropdown>
+            </Space>
 
-        {uploadedFiles.length > 0 && (
-          <div style={{ fontSize: '12px', color: '#666' }}>
-            已上传的抽奖箱配置文件：
-            {uploadedFiles.map((file, index) => (
-              <span key={index} style={{ marginRight: '8px' }}>
-                {file.name}
-              </span>
-            ))}
-          </div>
-        )}
-      </Space>
-      {items.length > 0 && <Collapse accordion items={items} />}
+            {uploadedFiles.length > 0 && (
+              <div style={{ fontSize: '12px', color: '#666' }}>
+                已上传的抽奖箱配置文件：
+                {uploadedFiles.map((file, index) => (
+                  <span key={index} style={{ marginRight: '8px' }}>
+                    {file.name}
+                  </span>
+                ))}
+              </div>
+            )}
+          </Space>
+          {items.length > 0 && <Collapse accordion items={items} />}
+        </>
+      )}
     </div>
   );
 };

--- a/src/services/lottery/wikiFormatter.ts
+++ b/src/services/lottery/wikiFormatter.ts
@@ -194,8 +194,9 @@ export function buildMarkdownTables(
     }));
     const lines: string[] = [];
     lines.push(`# ${displayName}`);
+    lines.push(`> 更新时间：${new Date().toISOString().replace('T', ' ').slice(0, 19)}`);
+    lines.push('');
     if (data.fallbackTimes > 0) {
-      lines.push('');
       lines.push(
         `抽取 ${data.fallbackTimes} 次后触发抽奖保底，会按照玩家商品拥有情况给予某一个保底奖励（保底商品会在"概率"一列中标注"保底"）。`,
       );

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -42,6 +42,18 @@ export function downloadCSV(csvData: string, fileName: string) {
   URL.revokeObjectURL(url);
 }
 
+export function downloadMarkdown(mdData: string, fileName: string) {
+  const blob = new Blob([mdData], { type: 'text/markdown;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = fileName.endsWith('.md') ? fileName : `${fileName}.md`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
 export function downloadCSVAsZip(fileArray: Record<string, string>, zipFileName: string) {
   const zip = new JSZip();
 


### PR DESCRIPTION
## Summary
- add standalone probability table export page with markdown preview and download options
- wire new page into navigation and routing
- include timestamp in exported markdown and support markdown downloads

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68af0b2472908322a8c9df06e585e4f1