### PR TITLE
feat: parse commodity durations for prefix items

### DIFF
--- a/src/pages/CommodityPage/CommodityTree.tsx
+++ b/src/pages/CommodityPage/CommodityTree.tsx
@@ -1,6 +1,7 @@
 import { Empty, Typography } from "antd";
 import React from "react";
 import { DifferentParts, CommodityData } from "../../services/commodity/compareCommodityData";
+import { formatDuration } from "../../utils/timeFormat";
 
 const { Paragraph } = Typography;
 
@@ -76,6 +77,21 @@ const CommodityTree: React.FC<CommodityTreeProps> = ({ fullJson, differentParts 
       ...differentParts.commonItems.map((item) => ({ ...item, _type: "common" })), // Include commonItems without special highlight
     ];
   }
+
+  // 🔹 格式化特定商品的 gain 字段，将秒数转换为可读时间
+  const prefixes = ["prefix", "ornament.", "pet.", "music.", "zb."];
+  processedJson.types.forEach((item: any) => {
+    const gain = item?.exchange?.fallbackExchange?.gain;
+    if (gain && typeof gain === "string") {
+      const [id, value] = gain.split(":");
+      const seconds = Number(value);
+      if (!Number.isNaN(seconds) && prefixes.some((p) => id.startsWith(p))) {
+        const human = formatDuration(seconds);
+        item.exchange.fallbackExchange.gain =
+          human === "永久" ? `${id}:${human}` : `${id}:${seconds}(${human})`;
+      }
+    }
+  });
 
   return (
     <Paragraph>

--- a/src/pages/CommodityPage/CommodityTree.tsx
+++ b/src/pages/CommodityPage/CommodityTree.tsx
@@ -81,14 +81,24 @@ const CommodityTree: React.FC<CommodityTreeProps> = ({ fullJson, differentParts 
   // 🔹 格式化特定商品的 gain 字段，将秒数转换为可读时间
   const prefixes = ["prefix", "ornament.", "pet.", "music.", "zb."];
   processedJson.types.forEach((item: any) => {
-    const gain = item?.exchange?.fallbackExchange?.gain;
-    if (gain && typeof gain === "string") {
-      const [id, value] = gain.split(":");
+    const fallback = item?.exchange?.fallbackExchange;
+    const gainStr =
+      typeof fallback === "string"
+        ? fallback
+        : typeof fallback?.gain === "string"
+        ? fallback.gain
+        : undefined;
+    if (gainStr) {
+      const [id, value] = gainStr.split(":");
       const seconds = Number(value);
       if (!Number.isNaN(seconds) && prefixes.some((p) => id.startsWith(p))) {
         const human = formatDuration(seconds);
-        item.exchange.fallbackExchange.gain =
-          human === "永久" ? `${id}:${human}` : `${id}:${seconds}(${human})`;
+        const formatted = `${id}:${human}`;
+        if (typeof fallback === "string") {
+          item.exchange.fallbackExchange = formatted;
+        } else {
+          item.exchange.fallbackExchange.gain = formatted;
+        }
       }
     }
   });

--- a/src/utils/timeFormat.ts
+++ b/src/utils/timeFormat.ts
@@ -1,0 +1,18 @@
+export function formatDuration(seconds: number): string {
+  if (seconds === 0 || seconds === 1) return '永久';
+  const units = [
+    { value: 31104000, label: '年' },
+    { value: 2592000, label: '月' },
+    { value: 86400, label: '天' },
+    { value: 3600, label: '小时' },
+    { value: 60, label: '分钟' },
+    { value: 1, label: '秒' }
+  ];
+  for (const unit of units) {
+    if (seconds >= unit.value) {
+      const count = Math.floor(seconds / unit.value);
+      return `${count}${unit.label}`;
+    }
+  }
+  return `${seconds}秒`;
+}


### PR DESCRIPTION
## Summary
- add utility to convert second values to human-readable durations
- format fallbackExchange gain for ornament/pet/music/zb prefixes to show duration or permanence

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68af3f5cda108322ae8dbfe1a8ccb59e