### PR TITLE
refactor: adjust lottery wiki tab behavior

### DIFF
--- a/src/services/lottery/wikiFormatter.ts
+++ b/src/services/lottery/wikiFormatter.ts
@@ -22,8 +22,6 @@ const DURATION_PREFIXES = ['prefix', 'ornament.', 'pet.', 'music.', 'zb.', 'sg.'
 
 function formatSecondsToReadable(seconds: number): string {
   const units = [
-    { label: '年', value: 365 * 24 * 3600 },
-    { label: '月', value: 30 * 24 * 3600 },
     { label: '天', value: 24 * 3600 },
     { label: '小时', value: 3600 },
     { label: '分钟', value: 60 }
@@ -229,7 +227,6 @@ export function buildMarkdownTables(
     const translatedItems = translateItems(data.items, nameMap);
     const lines: string[] = [];
     lines.push(`# ${displayName}`);
-    lines.push(`> 更新时间：${new Date().toISOString().replace('T', ' ').slice(0, 19)}`);
     lines.push('');
     if (data.fallbackTimes > 0) {
       lines.push(


### PR DESCRIPTION
## Summary
- strip month/year units from time parsing so durations max out at days
- streamline markdown export with single-file header and timestamp
- batch upload feedback and warn when translation data is missing

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68af54b5b5b88322b7c897d22653c0d5