### PR TITLE
refactor: centralize download trigger logic

### DIFF
--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -1,30 +1,25 @@
 import JSZip from 'jszip';
 import { saveAs } from 'file-saver';
 
+export function triggerDownload(blob: Blob, fileName: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = fileName;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
 export function downloadJson(jsonData: any, fileName: string) {
   // 使用 JSON.stringify 将 jsonData 转换为格式化的 JSON 字符串
   const dataStr = JSON.stringify(jsonData, null, 2);  // 这里的 `null, 2` 表示格式化 JSON 数据，2 表示每级缩进两个空格
 
   // 创建 Blob 对象，确保文件类型是 JSON 文件
   const blob = new Blob([dataStr], { type: 'application/json;charset=utf-8' });
-  
-  // 创建一个 URL 对象，以便生成下载链接
-  const url = URL.createObjectURL(blob);
 
-  // 创建一个锚点元素，用于触发下载
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = fileName;
-
-  // 触发点击事件以启动下载
-  document.body.appendChild(a);
-  a.click();
-
-  // 清理，移除锚点元素
-  document.body.removeChild(a);
-
-  // 释放 Blob URL
-  URL.revokeObjectURL(url);
+  triggerDownload(blob, fileName);
 }
 
 export function downloadCSV(csvData: string, fileName: string) {
@@ -32,26 +27,14 @@ export function downloadCSV(csvData: string, fileName: string) {
   const normalized = csvData.replace(/\r?\n/g, '\r\n'); // 统一为 CRLF
   const blob = new Blob([BOM, normalized], { type: 'text/csv;charset=utf-8;' });
 
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = fileName.endsWith('.csv') ? fileName : `${fileName}.csv`;
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  URL.revokeObjectURL(url);
+  const resolvedName = fileName.endsWith('.csv') ? fileName : `${fileName}.csv`;
+  triggerDownload(blob, resolvedName);
 }
 
 export function downloadMarkdown(mdData: string, fileName: string) {
   const blob = new Blob([mdData], { type: 'text/markdown;charset=utf-8' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = fileName.endsWith('.md') ? fileName : `${fileName}.md`;
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  URL.revokeObjectURL(url);
+  const resolvedName = fileName.endsWith('.md') ? fileName : `${fileName}.md`;
+  triggerDownload(blob, resolvedName);
 }
 
 export function downloadCSVAsZip(fileArray: Record<string, string>, zipFileName: string) {


### PR DESCRIPTION
## Summary
- add `triggerDownload` helper to handle anchor creation and blob URL cleanup
- refactor `downloadJson`, `downloadCSV`, and `downloadMarkdown` to reuse `triggerDownload`

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b02b7ab4308322a7b603642ec83236