### PR TITLE
feat: display fixed database IDs

### DIFF
--- a/src/pages/CommodityPage/CommodityTitleBar.tsx
+++ b/src/pages/CommodityPage/CommodityTitleBar.tsx
@@ -5,20 +5,18 @@ import { WorkshopPageContext } from "../WorkshopPage/WorkshopPageContext";
 const { Title, Text } = Typography;
 
 const CommodityTitleBar: React.FC = () => {
-  const { dirHandle, chooseDirectory, ensurePermission, messageApi } =
-    useContext(WorkshopPageContext);
+  const { dirHandle, chooseDirectory } = useContext(WorkshopPageContext);
 
   return (
     <Flex vertical gap={12} className="responsive-padding">
       <Title style={{ margin: "8px 0 16px" }}>Commodity 总分类 JSON 自动生成</Title>
 
-      {/* 让 Text 和 Input 在同一行 */}
       <Flex align="center" gap={12}>
         <Input
-          placeholder="请输入抽奖箱 Database ID"
           value="1959ff1f-c1d4-4754-9014-cd4f3c80c36f"
           style={{ width: 400 }}
           addonBefore="抽奖箱 Database ID："
+          disabled
         />
         {dirHandle && (
           <Text>
@@ -31,6 +29,6 @@ const CommodityTitleBar: React.FC = () => {
       </Flex>
     </Flex>
   );
-}
+};
 
 export default CommodityTitleBar;

--- a/src/pages/LotteryPage/LotteryTitleBar.tsx
+++ b/src/pages/LotteryPage/LotteryTitleBar.tsx
@@ -5,20 +5,18 @@ import { WorkshopPageContext } from "../WorkshopPage/WorkshopPageContext";
 const { Title, Text } = Typography;
 
 const LotteryTitleBar: React.FC = () => {
-  const { dirHandle, chooseDirectory, ensurePermission, messageApi } =
-    useContext(WorkshopPageContext);
+  const { dirHandle, chooseDirectory } = useContext(WorkshopPageContext);
 
   return (
     <Flex vertical gap={12} className="responsive-padding">
       <Title style={{ margin: "8px 0 0" }}>抽奖箱 JSON 同步</Title>
 
-      {/* 让 Text 和 Input 在同一行 */}
       <Flex align="center" gap={12}>
         <Input
-          placeholder="请输入抽奖箱 Database ID"
           value="9e151c3d30b14d1bae8dd972d17198c1"
           style={{ width: 400 }}
           addonBefore="抽奖箱 Database ID："
+          disabled
         />
         {dirHandle && (
           <Text>
@@ -31,6 +29,6 @@ const LotteryTitleBar: React.FC = () => {
       </Flex>
     </Flex>
   );
-}
+};
 
 export default LotteryTitleBar;


### PR DESCRIPTION
## Summary
- display uneditable database IDs in commodity and lottery title bars
- remove unused context variables and placeholders

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b05b050eb08322850336e706310426