### PR TITLE
feat: add info modals to pages

### DIFF
--- a/src/pages/CommodityPage/CommodityTitleBar.tsx
+++ b/src/pages/CommodityPage/CommodityTitleBar.tsx
@@ -1,15 +1,36 @@
-import React, { useContext } from "react";
-import { Typography, Flex, Button, Input } from "antd";
+import React, { useContext, useState } from "react";
+import { Typography, Flex, Button, Input, Modal } from "antd";
 import { WorkshopPageContext } from "../WorkshopPage/WorkshopPageContext";
+import { InfoCircleOutlined } from '@ant-design/icons';
 
 const { Title, Text } = Typography;
 
 const CommodityTitleBar: React.FC = () => {
   const { dirHandle, chooseDirectory } = useContext(WorkshopPageContext);
+  const [infoOpen, setInfoOpen] = useState(false);
 
   return (
     <Flex vertical gap={12} className="responsive-padding">
-      <Title style={{ margin: "8px 0 16px" }}>Commodity 总分类 JSON 自动生成</Title>
+      <Modal
+        title="Commodity 分类说明"
+        open={infoOpen}
+        onOk={() => setInfoOpen(false)}
+        onCancel={() => setInfoOpen(false)}
+      >
+        <Typography>
+          <Text>
+            从 Notion 商品分类数据库读取数据，生成包含全部分类层级的 JSON
+            文件，并保存到所选项目目录，供客户端读取商品分类配置。
+          </Text>
+        </Typography>
+      </Modal>
+      <div style={{ display: 'flex', alignItems: 'center', margin: '8px 0 16px' }}>
+        <Title style={{ margin: 0, flex: 1 }}>Commodity 总分类 JSON 自动生成</Title>
+        <InfoCircleOutlined
+          style={{ fontSize: 20, color: '#1677ff', cursor: 'pointer' }}
+          onClick={() => setInfoOpen(true)}
+        />
+      </div>
 
       <Flex align="center" gap={12}>
         <Input

--- a/src/pages/LegacyWorkshopPage.tsx
+++ b/src/pages/LegacyWorkshopPage.tsx
@@ -1,13 +1,14 @@
 import React, { useState } from 'react';
-import { Button, Checkbox, Space, Typography, Flex } from 'antd';
+import { Button, Checkbox, Space, Typography, Flex, Modal } from 'antd';
 import { getNotionToken, fetchNotionAllPages } from '../notion/notionClient';
 import { formatWorkshop } from '../services/workshop/workshopService';
 import JSZip from 'jszip';
 import { saveAs } from 'file-saver';
 import useMessage from "antd/es/message/useMessage";
 import { NOTION_DATABASE_WORKSHOP, WORKSHOP_TYPES } from "../services/workshop/workshopNotionQueries";
+import { InfoCircleOutlined } from '@ant-design/icons';
 
-const { Title } = Typography;
+const { Title, Paragraph } = Typography;
 
 const LegacyWorkshopPage: React.FC = () => {
   const [checkedTypes, setCheckedTypes] = useState<string[]>(Object.keys(WORKSHOP_TYPES));
@@ -87,10 +88,31 @@ const LegacyWorkshopPage: React.FC = () => {
     }
   };
 
+  const [infoOpen, setInfoOpen] = useState(false);
+
   return (
     <div className="responsive-padding">
       {messageContext}
-      <Title style={{ margin: "8px 0 16px" }}>商品表 JSON 生成（旧版）</Title>
+      <Modal
+        title="旧版商品表说明"
+        open={infoOpen}
+        onOk={() => setInfoOpen(false)}
+        onCancel={() => setInfoOpen(false)}
+      >
+        <Typography>
+          <Paragraph>
+            选择需要的商品类型后，从 Notion 旧版商品数据库拉取数据，生成对应的
+            JSON 文件，并打包成 zip 提供下载，便于离线导入旧版项目。
+          </Paragraph>
+        </Typography>
+      </Modal>
+      <div style={{ display: 'flex', alignItems: 'center', margin: '8px 0 16px' }}>
+        <Title style={{ margin: 0, flex: 1 }}>商品表 JSON 生成（旧版）</Title>
+        <InfoCircleOutlined
+          style={{ fontSize: 20, color: '#1677ff', cursor: 'pointer' }}
+          onClick={() => setInfoOpen(true)}
+        />
+      </div>
       <Space style={{ marginBottom: 16 }}>
         <Button onClick={selectAll}>全选</Button>
         <Button onClick={deselectAll}>全不选</Button>

--- a/src/pages/LotteryPage/LotteryTitleBar.tsx
+++ b/src/pages/LotteryPage/LotteryTitleBar.tsx
@@ -1,15 +1,36 @@
-import React, { useContext } from "react";
-import { Typography, Flex, Button, Input } from "antd";
+import React, { useContext, useState } from "react";
+import { Typography, Flex, Button, Input, Modal } from "antd";
 import { WorkshopPageContext } from "../WorkshopPage/WorkshopPageContext";
+import { InfoCircleOutlined } from '@ant-design/icons';
 
 const { Title, Text } = Typography;
 
 const LotteryTitleBar: React.FC = () => {
   const { dirHandle, chooseDirectory } = useContext(WorkshopPageContext);
+  const [infoOpen, setInfoOpen] = useState(false);
 
   return (
     <Flex vertical gap={12} className="responsive-padding">
-      <Title style={{ margin: "8px 0 0" }}>抽奖箱 JSON 同步</Title>
+      <Modal
+        title="抽奖箱同步说明"
+        open={infoOpen}
+        onOk={() => setInfoOpen(false)}
+        onCancel={() => setInfoOpen(false)}
+      >
+        <Typography>
+          <Text>
+            读取 Notion 抽奖箱数据库中的奖品及概率设置，生成相应的 JSON
+            配置文件，并同步到所选项目目录，供抽奖逻辑使用。
+          </Text>
+        </Typography>
+      </Modal>
+      <div style={{ display: 'flex', alignItems: 'center', margin: '8px 0 0' }}>
+        <Title style={{ margin: 0, flex: 1 }}>抽奖箱 JSON 同步</Title>
+        <InfoCircleOutlined
+          style={{ fontSize: 20, color: '#1677ff', cursor: 'pointer' }}
+          onClick={() => setInfoOpen(true)}
+        />
+      </div>
 
       <Flex align="center" gap={12}>
         <Input

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -14,7 +14,9 @@ const SettingsPage: React.FC = () => {
 
   return (
     <div className="responsive-padding">
-      <Title style={{ margin: "8px 0 24px" }}>设置</Title>
+      <div style={{ display: 'flex', alignItems: 'center', margin: '8px 0 24px' }}>
+        <Title style={{ margin: 0, flex: 1 }}>设置</Title>
+      </div>
       <Form
         form={form}
         initialValues={{ notionToken: token }}

--- a/src/pages/WelcomePage.tsx
+++ b/src/pages/WelcomePage.tsx
@@ -13,7 +13,9 @@ const WelcomePage: React.FC = () => {
   return (
     <Layout style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', height: '100vh' }}>
       <Content style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', textAlign: 'center', flex: 1, paddingBottom: 80 }}>
-        <Title level={2}>欢迎使用 EC 配置生成工具</Title>
+        <div style={{ display: 'flex', alignItems: 'center', marginBottom: 32 }}>
+          <Title level={2} style={{ margin: 0, flex: 1 }}>欢迎使用 EC 配置生成工具</Title>
+        </div>
         <Paragraph style={{ marginBottom: 32 }}>
           请先输入 Notion Token 以继续使用
         </Paragraph>

--- a/src/pages/WorkshopPage/WorkshopTitleBar.tsx
+++ b/src/pages/WorkshopPage/WorkshopTitleBar.tsx
@@ -1,16 +1,37 @@
-import React, { useContext } from "react";
-import { Typography, Flex, Button } from "antd";
+import React, { useContext, useState } from "react";
+import { Typography, Flex, Button, Modal } from "antd";
 import { WorkshopPageContext } from "./WorkshopPageContext";
+import { InfoCircleOutlined } from '@ant-design/icons';
 
 const { Title, Text } = Typography;
 
 const WorkshopTitleBar: React.FC = () => {
   const { dirHandle, chooseDirectory, ensurePermission, messageApi } =
     useContext(WorkshopPageContext);
+  const [infoOpen, setInfoOpen] = useState(false);
 
   return (
     <Flex vertical gap={12} className={"responsive-padding"}>
-      <Title style={{ margin: "8px 0 0" }}>商品表 JSON 同步</Title>
+      <Modal
+        title="商品表同步说明"
+        open={infoOpen}
+        onOk={() => setInfoOpen(false)}
+        onCancel={() => setInfoOpen(false)}
+      >
+        <Typography>
+          <Text>
+            连接 Notion 商品表数据库，拉取所有商品记录，生成对应的 JSON
+            配置文件并写入所选项目目录，用于商城或其他功能的商品数据。
+          </Text>
+        </Typography>
+      </Modal>
+      <div style={{ display: 'flex', alignItems: 'center', margin: '8px 0 0' }}>
+        <Title style={{ margin: 0, flex: 1 }}>商品表 JSON 同步</Title>
+        <InfoCircleOutlined
+          style={{ fontSize: 20, color: '#1677ff', cursor: 'pointer' }}
+          onClick={() => setInfoOpen(true)}
+        />
+      </div>
       { dirHandle && (
         <Text>
           已选择的项目目录：{dirHandle.name}


### PR DESCRIPTION
## Summary
- add detailed info buttons and modals to Commodity, Lottery, Workshop, and Legacy Workshop pages
- remove info modals from Welcome and Settings pages per feedback

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68b028f3ad548322a78db58babba75be